### PR TITLE
week8課題 (順序のランダム化)

### DIFF
--- a/scripts/quiz.js
+++ b/scripts/quiz.js
@@ -85,7 +85,6 @@ const shuffleArray = (array) => {
     quiz.choices = shuffleArray(quiz.choices);
   });
   quizzes = shuffleArray(quizzes);
-  console.log(quizzes);
 
   const quizzesWrapperElement = document.querySelector(
     "." + CLASS_QUIZZES_WRAPPER

--- a/scripts/quiz.js
+++ b/scripts/quiz.js
@@ -1,6 +1,6 @@
 "use-strict";
 
-const quizzes = [
+let quizzes = [
   {
     question:
       "日本のIT人材が2030年には最大どれくらい不足すると言われているでしょうか？",
@@ -52,6 +52,7 @@ const quizzes = [
 ];
 
 const ASSET_PATH = "../";
+
 const CLASS_QUIZZES_WRAPPER = "js-quizzesWrapper";
 const CLASS_CHOICE = "js-quizChoice";
 const CLASS_QUIZ = "js-quiz";
@@ -68,8 +69,24 @@ const CLASS_ANSWER_TEXT = "js-quizAnswerText";
 
 const CLASS_HIDDEN = "u-state__hidden";
 
+// https://www.softel.co.jp/blogs/tech/archives/2328
+const shuffleArray = (array) => {
+  return array
+    .map((elem) => {
+      return { weight: Math.random(), value: elem };
+    })
+    .sort((a, b) => a.weight - b.weight)
+    .map((elem) => elem.value);
+};
+
 // setup for quiz
 {
+  quizzes.forEach((quiz) => {
+    quiz.choices = shuffleArray(quiz.choices);
+  });
+  quizzes = shuffleArray(quizzes);
+  console.log(quizzes);
+
   const quizzesWrapperElement = document.querySelector(
     "." + CLASS_QUIZZES_WRAPPER
   );


### PR DESCRIPTION
## 今週の課題

- [x] 設問数を増やす場合でもhtmlファイル、cssファイルの修正が不要な作りになっていますか？→css,htmlを触らずにjsだけで、設問数を増やせる仕様になっていますか？
- [ ] Figmaと比べてサイズや幅の違いはありませんか？
- [x] ページをリロードすると問題と選択肢の順番が変わりますか？
- [x] GitHubにプルリクできましたか？

## 注意点やレビュワーに伝えたいこと(あれば)
- 8-1の課題が7と一緒かも（https://github.com/posse-ap/drill-ph1/tree/main/week8-1）

## 課題が終わっている証跡(スクショ)

https://user-images.githubusercontent.com/69781798/182364854-be5fa238-e466-4022-94c0-b8647755d0eb.mov


